### PR TITLE
support win32.

### DIFF
--- a/Makefile.w32
+++ b/Makefile.w32
@@ -1,0 +1,19 @@
+TARGET=mod_mruby.c ap_mrb_request.c ap_mrb_string.c ap_mrb_utils.c
+
+APXS=apxs
+
+INC=-I. -I../mruby/src -I../mruby/include
+APACHE_ROOT=c:/progra~1/apache~1/apache2.2
+LIB=-lm ../mruby/lib/libmruby.a -llibapr-1 -llibaprutil-1 -llibhttpd -lws2_32
+DEF=-DAPR_DECLARE_EXPORT
+
+all: mod_mruby.so
+
+mod_mruby.so: $(TARGET)
+	$(APXS) -c $(DEF) $(INC) $(TARGET) $(LIB)
+
+install: all
+	$(APXS) -i -a -n "mruby" .libs/mod_mruby.so
+
+clean:
+	-rm -rf .libs *.o *.so *.lo *.la *.slo *.loT

--- a/ap_mrb_utils.c
+++ b/ap_mrb_utils.c
@@ -1,6 +1,13 @@
 #include "mod_mruby.h"
 #include "ap_mrb_utils.h"
 
+#ifndef _WIN32
+#define SUPPORT_SYSLOG
+#else
+#define sleep(x) Sleep(x*1000)
+#endif
+
+#ifdef SUPPORT_SYSLOG
 CODE logpriority[] =
 {
     { "alert", LOG_ALERT },
@@ -16,6 +23,7 @@ CODE logpriority[] =
     { "warning", LOG_WARNING },
     { NULL, -1 }
 };
+#endif
 
 
 int ap_mrb_get_status_code()
@@ -104,6 +112,7 @@ mrb_value ap_mrb_errlogger(mrb_state *mrb, mrb_value str)
 mrb_value ap_mrb_syslogger(mrb_state *mrb, mrb_value str)
 {   
 
+#ifdef SUPPORT_SYSLOG
     struct RProc *b;
     mrb_value argc, *argv;
     char *i_pri,*msg;
@@ -151,6 +160,7 @@ mrb_value ap_mrb_syslogger(mrb_state *mrb, mrb_value str)
     openlog(NULL, LOG_PID, LOG_SYSLOG);
     syslog(pri, msg);
     closelog();
+#endif
 
     return str;
 

--- a/ap_mrb_utils.h
+++ b/ap_mrb_utils.h
@@ -1,9 +1,13 @@
 #ifndef AP_MRB_UTILS_H
 #define AP_MRB_UTILS_H
 
+#ifndef _WIN32
 #include <unistd.h>
 #include <string.h>
 #include <sys/syslog.h>
+#else
+#include <string.h>
+#endif
 #include "mruby.h"
 
 

--- a/mod_mruby.c
+++ b/mod_mruby.c
@@ -42,7 +42,9 @@
 #include "http_request.h"
 
 #include "apr_global_mutex.h"
+#ifndef _WIN32
 #include "unixd.h"
+#endif
 
 #include <mruby/proc.h>
 #include <compile.h>


### PR DESCRIPTION
windows で動く様にしました。

Apache.rputs 以外に出力方法がなく、ヘッダを `Content-Type: text/html` に変更出来なかった(.htaccessとかで弄れば出来ますが)ので、`<h5>hellow mod_mruby world!</h5>` が出た事で確認しました。
