### PR TITLE
mod_mrubyで扱えるrequest_rec構造体メンバを追加しました。

### DIFF
--- a/ap_mrb_request.c
+++ b/ap_mrb_request.c
@@ -89,34 +89,6 @@ mrb_value ap_mrb_get_request_rec_json(mrb_state *mrb, mrb_value str)
 }
 
 
-mrb_value ap_mrb_get_request_filename(mrb_state *mrb, mrb_value str)
-{
-    request_rec *r = ap_mrb_get_request();
-    char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->filename));
-    return mrb_str_new(mrb, val, strlen(val));
-}
-
-mrb_value ap_mrb_get_request_uri(mrb_state *mrb, mrb_value str)
-{
-    request_rec *r = ap_mrb_get_request();
-    char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->uri));
-    return mrb_str_new(mrb, val, strlen(val));
-}
-
-mrb_value ap_mrb_get_request_user(mrb_state *mrb, mrb_value str)
-{
-    request_rec *r = ap_mrb_get_request();
-    char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->user));
-    return mrb_str_new(mrb, val, strlen(val));
-}
-
-mrb_value ap_mrb_get_request_content_type(mrb_state *mrb, mrb_value str)
-{
-    request_rec *r = ap_mrb_get_request();
-    const char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->content_type));
-    return mrb_str_new(mrb, val, strlen(val));
-}
-
 mrb_value ap_mrb_get_request_the_request(mrb_state *mrb, mrb_value str)
 {
     request_rec *r = ap_mrb_get_request();
@@ -138,6 +110,13 @@ mrb_value ap_mrb_get_request_vlist_validator(mrb_state *mrb, mrb_value str)
     return mrb_str_new(mrb, val, strlen(val));
 }
 
+mrb_value ap_mrb_get_request_user(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->user));
+    return mrb_str_new(mrb, val, strlen(val));
+}
+
 mrb_value ap_mrb_get_request_ap_auth_type(mrb_state *mrb, mrb_value str)
 {
     request_rec *r = ap_mrb_get_request();
@@ -149,6 +128,20 @@ mrb_value ap_mrb_get_request_unparsed_uri(mrb_state *mrb, mrb_value str)
 {
     request_rec *r = ap_mrb_get_request();
     char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->unparsed_uri));
+    return mrb_str_new(mrb, val, strlen(val));
+}
+
+mrb_value ap_mrb_get_request_uri(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->uri));
+    return mrb_str_new(mrb, val, strlen(val));
+}
+
+mrb_value ap_mrb_get_request_filename(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->filename));
     return mrb_str_new(mrb, val, strlen(val));
 }
 
@@ -166,48 +159,62 @@ mrb_value ap_mrb_get_request_path_info(mrb_state *mrb, mrb_value str)
     return mrb_str_new(mrb, val, strlen(val));
 }
 
-mrb_value ap_mrb_get_request_hostname(mrb_state *mrb, mrb_value str)
+mrb_value ap_mrb_get_request_args(mrb_state *mrb, mrb_value str)
 {
     request_rec *r = ap_mrb_get_request();
-    const char *val = apr_pstrdup(r->pool, r->hostname);
+    char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->args));
     return mrb_str_new(mrb, val, strlen(val));
 }
 
-mrb_value ap_mrb_set_request_filename(mrb_state *mrb, mrb_value str)
+mrb_value ap_mrb_get_request_hostname(mrb_state *mrb, mrb_value str)
 {
-    mrb_value val;
     request_rec *r = ap_mrb_get_request();
-    mrb_get_args(mrb, "o", &val);
-    r->filename = apr_pstrdup(r->pool, RSTRING_PTR(val));
-    return val;
+    const char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool,r->hostname));
+    return mrb_str_new(mrb, val, strlen(val));
 }
 
-mrb_value ap_mrb_set_request_uri(mrb_state *mrb, mrb_value str)
+mrb_value ap_mrb_get_request_status_line(mrb_state *mrb, mrb_value str)
 {
-    mrb_value val;
     request_rec *r = ap_mrb_get_request();
-    mrb_get_args(mrb, "o", &val);
-    r->uri = apr_pstrdup(r->pool, RSTRING_PTR(val));
-    return val;
+    const char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool,r->status_line));
+    return mrb_str_new(mrb, val, strlen(val));
 }
 
-mrb_value ap_mrb_set_request_user(mrb_state *mrb, mrb_value str)
+mrb_value ap_mrb_get_request_method(mrb_state *mrb, mrb_value str)
 {
-    mrb_value val;
     request_rec *r = ap_mrb_get_request();
-    mrb_get_args(mrb, "o", &val);
-    r->user = apr_pstrdup(r->pool, RSTRING_PTR(val));
-    return val;
+    const char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool,r->method));
+    return mrb_str_new(mrb, val, strlen(val));
 }
 
-mrb_value ap_mrb_set_request_content_type(mrb_state *mrb, mrb_value str)
+mrb_value ap_mrb_get_request_range(mrb_state *mrb, mrb_value str)
 {
-    mrb_value val;
     request_rec *r = ap_mrb_get_request();
-    mrb_get_args(mrb, "o", &val);
-    r->content_type = apr_pstrdup(r->pool, RSTRING_PTR(val));
-    return val;
+    const char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool,r->range));
+    return mrb_str_new(mrb, val, strlen(val));
 }
+
+mrb_value ap_mrb_get_request_content_type(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    const char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->content_type));
+    return mrb_str_new(mrb, val, strlen(val));
+}
+
+mrb_value ap_mrb_get_request_handler(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    const char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->handler));
+    return mrb_str_new(mrb, val, strlen(val));
+}
+
+mrb_value ap_mrb_get_request_content_encoding(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    const char *val = apr_pstrdup(r->pool, ap_mrb_string_check(r->pool, r->content_encoding));
+    return mrb_str_new(mrb, val, strlen(val));
+}
+
 
 mrb_value ap_mrb_set_request_the_request(mrb_state *mrb, mrb_value str)
 {
@@ -236,6 +243,15 @@ mrb_value ap_mrb_set_request_vlist_validator(mrb_state *mrb, mrb_value str)
     return val;
 }
 
+mrb_value ap_mrb_set_request_user(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->user = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
 mrb_value ap_mrb_set_request_ap_auth_type(mrb_state *mrb, mrb_value str)
 {
     mrb_value val;
@@ -251,6 +267,24 @@ mrb_value ap_mrb_set_request_unparsed_uri(mrb_state *mrb, mrb_value str)
     request_rec *r = ap_mrb_get_request();
     mrb_get_args(mrb, "o", &val);
     r->unparsed_uri = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
+mrb_value ap_mrb_set_request_uri(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->uri = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
+mrb_value ap_mrb_set_request_filename(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->filename = apr_pstrdup(r->pool, RSTRING_PTR(val));
     return val;
 }
 
@@ -271,6 +305,16 @@ mrb_value ap_mrb_set_request_path_info(mrb_state *mrb, mrb_value str)
     r->path_info = apr_pstrdup(r->pool, RSTRING_PTR(val));
     return val;
 }
+
+mrb_value ap_mrb_set_request_args(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->args = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
 
 mrb_value ap_mrb_write_request(mrb_state *mrb, mrb_value str)
 {   

--- a/ap_mrb_request.h
+++ b/ap_mrb_request.h
@@ -12,30 +12,37 @@ request_rec *ap_mrb_get_request();
 mrb_value ap_mrb_init_request(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_rec_json(mrb_state *mrb, mrb_value str);
 
-mrb_value ap_mrb_get_request_filename(mrb_state *mrb, mrb_value str);
-mrb_value ap_mrb_get_request_uri(mrb_state *mrb, mrb_value str);
-mrb_value ap_mrb_get_request_user(mrb_state *mrb, mrb_value str);
-mrb_value ap_mrb_get_request_content_type(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_the_request(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_protocol(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_vlist_validator(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_user(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_ap_auth_type(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_unparsed_uri(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_uri(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_filename(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_canonical_filename(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_path_info(mrb_state *mrb, mrb_value str);
-mrb_value ap_mrb_get_request_hostname(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_args(mrb_state *mrb, mrb_value str);
 
-mrb_value ap_mrb_set_request_filename(mrb_state *mrb, mrb_value str);
-mrb_value ap_mrb_set_request_uri(mrb_state *mrb, mrb_value str);
-mrb_value ap_mrb_set_request_user(mrb_state *mrb, mrb_value str);
-mrb_value ap_mrb_set_request_content_type(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_hostname(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_status_line(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_method(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_range(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_content_type(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_handler(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_content_encoding(mrb_state *mrb, mrb_value str);
+
 mrb_value ap_mrb_set_request_the_request(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_protocol(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_vlist_validator(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_user(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_ap_auth_type(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_unparsed_uri(mrb_state *mrb, mrb_value str);
-mrb_value ap_mrb_set_request_path_info(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_uri(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_filename(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_canonical_filename(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_path_info(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_args(mrb_state *mrb, mrb_value str);
 
 mrb_value ap_mrb_write_request_filename(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_write_request(mrb_state *mrb, mrb_value str);

--- a/mod_mruby.c
+++ b/mod_mruby.c
@@ -439,29 +439,37 @@ static int ap_mruby_class_init(mrb_state *mrb)
     class_request = mrb_define_class_under(mrb, class, "Request", mrb->object_class);
     mrb_define_method(mrb, class_request, "Initialize", ap_mrb_init_request, ARGS_NONE());
     mrb_define_method(mrb, class_request, "request_rec_json", ap_mrb_get_request_rec_json, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "filename=", ap_mrb_set_request_filename, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "filename", ap_mrb_get_request_filename, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "uri=", ap_mrb_set_request_uri, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "uri", ap_mrb_get_request_uri, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "user=", ap_mrb_set_request_user, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "user", ap_mrb_get_request_user, ARGS_NONE());
-    mrb_define_method(mrb, class_request, "content_type=", ap_mrb_set_request_content_type, ARGS_ANY());
-    mrb_define_method(mrb, class_request, "content_type", ap_mrb_get_request_content_type, ARGS_NONE());
     mrb_define_method(mrb, class_request, "the_request=", ap_mrb_set_request_the_request, ARGS_ANY());
     mrb_define_method(mrb, class_request, "the_request", ap_mrb_get_request_the_request, ARGS_NONE());
     mrb_define_method(mrb, class_request, "protocol=", ap_mrb_set_request_protocol, ARGS_ANY());
     mrb_define_method(mrb, class_request, "protocol", ap_mrb_get_request_protocol, ARGS_NONE());
     mrb_define_method(mrb, class_request, "vlist_validator=", ap_mrb_set_request_vlist_validator, ARGS_ANY());
     mrb_define_method(mrb, class_request, "vlist_validator", ap_mrb_get_request_vlist_validator, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "user=", ap_mrb_set_request_user, ARGS_ANY());
+    mrb_define_method(mrb, class_request, "user", ap_mrb_get_request_user, ARGS_NONE());
     mrb_define_method(mrb, class_request, "ap_auth_type=", ap_mrb_set_request_ap_auth_type, ARGS_ANY());
     mrb_define_method(mrb, class_request, "ap_auth_type", ap_mrb_get_request_ap_auth_type, ARGS_NONE());
     mrb_define_method(mrb, class_request, "unparsed_uri=", ap_mrb_set_request_unparsed_uri, ARGS_ANY());
     mrb_define_method(mrb, class_request, "unparsed_uri", ap_mrb_get_request_unparsed_uri, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "uri=", ap_mrb_set_request_uri, ARGS_ANY());
+    mrb_define_method(mrb, class_request, "uri", ap_mrb_get_request_uri, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "filename=", ap_mrb_set_request_filename, ARGS_ANY());
+    mrb_define_method(mrb, class_request, "filename", ap_mrb_get_request_filename, ARGS_NONE());
     mrb_define_method(mrb, class_request, "canonical_filename=", ap_mrb_set_request_canonical_filename, ARGS_ANY());
     mrb_define_method(mrb, class_request, "canonical_filename", ap_mrb_get_request_canonical_filename, ARGS_NONE());
     mrb_define_method(mrb, class_request, "path_info=", ap_mrb_set_request_path_info, ARGS_ANY());
     mrb_define_method(mrb, class_request, "path_info", ap_mrb_get_request_path_info, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "args=", ap_mrb_set_request_args, ARGS_ANY());
+    mrb_define_method(mrb, class_request, "args", ap_mrb_get_request_args, ARGS_NONE());
+
     mrb_define_method(mrb, class_request, "hostname", ap_mrb_get_request_hostname, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "status_line", ap_mrb_get_request_status_line, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "method", ap_mrb_get_request_method, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "range", ap_mrb_get_request_range, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "content_type", ap_mrb_get_request_content_type, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "handler", ap_mrb_get_request_handler, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "content_encoding", ap_mrb_get_request_content_encoding, ARGS_NONE());
+
 
     return OK;
 }


### PR DESCRIPTION
char型、const char型で扱われているメンバを追加しましたので反映をお願いします。

-char型
the_request
protocol
vlist_validator
user
ap_auth_type
unparsed_uri
uri
filename
canonical_filename
path_info
args

-const char型
hostname
status_line
method
content_type
handler
content_encoding
