### PR TITLE
mod_mrubyで扱えるrequest_rec構造体でint型のメンバを追加しました。

### DIFF
--- a/ap_mrb_request.c
+++ b/ap_mrb_request.c
@@ -316,6 +316,98 @@ mrb_value ap_mrb_set_request_args(mrb_state *mrb, mrb_value str)
 }
 
 
+mrb_value ap_mrb_get_request_assbackwards(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->assbackwards;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_proxyreq(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->proxyreq;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_header_only(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->header_only;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_proto_num(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->proto_num;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_status(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->status;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_method_number(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->method_number;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_chunked(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->chunked;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_read_body(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->read_body;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_read_chunked(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->read_chunked;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_used_path_info(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->used_path_info;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_eos_sent(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->eos_sent;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_no_cache(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->no_cache;
+    return mrb_fixnum_value(val);
+}
+
+mrb_value ap_mrb_get_request_no_local_copy(mrb_state *mrb, mrb_value str)
+{
+    request_rec *r = ap_mrb_get_request();
+    int val = r->no_local_copy;
+    return mrb_fixnum_value(val);
+}
+
+
 mrb_value ap_mrb_write_request(mrb_state *mrb, mrb_value str)
 {   
 

--- a/ap_mrb_request.h
+++ b/ap_mrb_request.h
@@ -44,6 +44,20 @@ mrb_value ap_mrb_set_request_canonical_filename(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_path_info(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_args(mrb_state *mrb, mrb_value str);
 
+mrb_value ap_mrb_get_request_assbackwards(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_proxyreq(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_header_only(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_proto_num(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_status(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_method_number(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_chunked(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_read_body(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_read_chunked(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_used_path_info(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_eos_sent(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_no_cache(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_request_no_local_copy(mrb_state *mrb, mrb_value str);
+
 mrb_value ap_mrb_write_request_filename(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_write_request(mrb_state *mrb, mrb_value str);
 

--- a/mod_mruby.c
+++ b/mod_mruby.c
@@ -470,6 +470,20 @@ static int ap_mruby_class_init(mrb_state *mrb)
     mrb_define_method(mrb, class_request, "handler", ap_mrb_get_request_handler, ARGS_NONE());
     mrb_define_method(mrb, class_request, "content_encoding", ap_mrb_get_request_content_encoding, ARGS_NONE());
 
+    mrb_define_method(mrb, class_request, "assbackwards", ap_mrb_get_request_assbackwards, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "proxyreq", ap_mrb_get_request_proxyreq, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "header_only", ap_mrb_get_request_header_only, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "proto_num", ap_mrb_get_request_proto_num, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "status", ap_mrb_get_request_status, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "method_number", ap_mrb_get_request_method_number, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "chunked", ap_mrb_get_request_chunked, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "read_body", ap_mrb_get_request_read_body, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "read_chunked", ap_mrb_get_request_read_chunked, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "used_path_info", ap_mrb_get_request_used_path_info, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "eos_sent", ap_mrb_get_request_eos_sent, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "no_cache", ap_mrb_get_request_no_cache, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "no_local_copy", ap_mrb_get_request_no_local_copy, ARGS_NONE());
+
 
     return OK;
 }


### PR DESCRIPTION
request_rec内でint型で宣言されているメンバを追加しました。
現状はgetの機能のみ追加しています。
追加したメンバは以下の通りです。
    assbackwards
    proxyreq
    header_only
    proto_num
    status
    method_number
    chunked
    read_body
    read_chunked
    used_path_info
    eos_sent
    no_cache
    no_local_copy
