### PR TITLE
mod_mruby.c, ap_mrb_request.c and ap_mrb_request.h modified

### DIFF
--- a/ap_mrb_request.c
+++ b/ap_mrb_request.c
@@ -315,6 +315,24 @@ mrb_value ap_mrb_set_request_args(mrb_state *mrb, mrb_value str)
     return val;
 }
 
+mrb_value ap_mrb_set_request_content_type(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->content_type = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
+mrb_value ap_mrb_set_request_handler(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->handler = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
 
 mrb_value ap_mrb_get_request_assbackwards(mrb_state *mrb, mrb_value str)
 {

--- a/ap_mrb_request.h
+++ b/ap_mrb_request.h
@@ -45,6 +45,9 @@ mrb_value ap_mrb_set_request_canonical_filename(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_path_info(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_args(mrb_state *mrb, mrb_value str);
 
+mrb_value ap_mrb_set_request_content_type(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_handler(mrb_state *mrb, mrb_value str);
+
 mrb_value ap_mrb_get_request_assbackwards(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_proxyreq(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_header_only(mrb_state *mrb, mrb_value str);

--- a/mod_mruby.c
+++ b/mod_mruby.c
@@ -459,7 +459,9 @@ static int ap_mruby_class_init(mrb_state *mrb)
     mrb_define_method(mrb, class_request, "status_line", ap_mrb_get_request_status_line, ARGS_NONE());
     mrb_define_method(mrb, class_request, "method", ap_mrb_get_request_method, ARGS_NONE());
     mrb_define_method(mrb, class_request, "range", ap_mrb_get_request_range, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "content_type=", ap_mrb_set_request_content_type, ARGS_ANY());
     mrb_define_method(mrb, class_request, "content_type", ap_mrb_get_request_content_type, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "handler=", ap_mrb_set_request_handler, ARGS_ANY());
     mrb_define_method(mrb, class_request, "handler", ap_mrb_get_request_handler, ARGS_NONE());
     mrb_define_method(mrb, class_request, "content_encoding", ap_mrb_get_request_content_encoding, ARGS_NONE());
 


### PR DESCRIPTION
request_rec構造体内のcontent_typeとhandlerをset関数で書き換えできるように修正しました。
