### PR TITLE
ap_mrb_server.c ap_mrb_server.h modified

### DIFF
--- a/ap_mrb_server.c
+++ b/ap_mrb_server.c
@@ -2,9 +2,9 @@
 #include "ap_mrb_server.h"
 #include "json.h"
 
-static struct mrb_data_type server_rec_type = {
-    "server_rec", 0,
-};
+//static struct mrb_data_type server_rec_type = {
+//    "server_rec", 0,
+//};
 
 // char
 mrb_value ap_mrb_set_server_error_fname(mrb_state *mrb, mrb_value str)

--- a/ap_mrb_server.h
+++ b/ap_mrb_server.h
@@ -4,6 +4,7 @@
 #include <string.h>
 #include "apr_strings.h"
 #include "http_request.h"
+#include "http_core.h"
 #include "mruby.h"
 #include "mruby/data.h"
 #include "mruby/variable.h"


### PR DESCRIPTION
コンパイル時にwarningが出ていたので修正しました。
http_core.hの追加と、server_rec_typeを使用していなかったので一旦コメントアウトしております。
