### PR TITLE
ap_mrb_init.c, ap_mrb_request.h and ap_mrb_request.c modified

### DIFF
--- a/ap_mrb_init.c
+++ b/ap_mrb_init.c
@@ -104,14 +104,19 @@ int ap_mruby_class_init(mrb_state *mrb)
     mrb_define_method(mrb, class_request, "args=", ap_mrb_set_request_args, ARGS_ANY());
     mrb_define_method(mrb, class_request, "args", ap_mrb_get_request_args, ARGS_NONE());
 
+    mrb_define_method(mrb, class_request, "hostname=", ap_mrb_set_request_hostname, ARGS_ANY());
     mrb_define_method(mrb, class_request, "hostname", ap_mrb_get_request_hostname, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "status_line=", ap_mrb_set_request_status_line, ARGS_ANY());
     mrb_define_method(mrb, class_request, "status_line", ap_mrb_get_request_status_line, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "method=", ap_mrb_set_request_method, ARGS_ANY());
     mrb_define_method(mrb, class_request, "method", ap_mrb_get_request_method, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "range=", ap_mrb_set_request_range, ARGS_ANY());
     mrb_define_method(mrb, class_request, "range", ap_mrb_get_request_range, ARGS_NONE());
     mrb_define_method(mrb, class_request, "content_type=", ap_mrb_set_request_content_type, ARGS_ANY());
     mrb_define_method(mrb, class_request, "content_type", ap_mrb_get_request_content_type, ARGS_NONE());
     mrb_define_method(mrb, class_request, "handler=", ap_mrb_set_request_handler, ARGS_ANY());
     mrb_define_method(mrb, class_request, "handler", ap_mrb_get_request_handler, ARGS_NONE());
+    mrb_define_method(mrb, class_request, "content_encoding=", ap_mrb_set_request_content_encoding, ARGS_ANY());
     mrb_define_method(mrb, class_request, "content_encoding", ap_mrb_get_request_content_encoding, ARGS_NONE());
 
     mrb_define_method(mrb, class_request, "assbackwards", ap_mrb_get_request_assbackwards, ARGS_NONE());

--- a/ap_mrb_request.c
+++ b/ap_mrb_request.c
@@ -315,6 +315,42 @@ mrb_value ap_mrb_set_request_args(mrb_state *mrb, mrb_value str)
     return val;
 }
 
+mrb_value ap_mrb_set_request_hostname(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->hostname = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
+mrb_value ap_mrb_set_request_status_line(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->status_line = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
+mrb_value ap_mrb_set_request_method(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->method = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
+mrb_value ap_mrb_set_request_range(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->range = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
 mrb_value ap_mrb_set_request_content_type(mrb_state *mrb, mrb_value str)
 {
     mrb_value val;
@@ -330,6 +366,15 @@ mrb_value ap_mrb_set_request_handler(mrb_state *mrb, mrb_value str)
     request_rec *r = ap_mrb_get_request();
     mrb_get_args(mrb, "o", &val);
     r->handler = apr_pstrdup(r->pool, RSTRING_PTR(val));
+    return val;
+}
+
+mrb_value ap_mrb_set_request_content_encoding(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    request_rec *r = ap_mrb_get_request();
+    mrb_get_args(mrb, "o", &val);
+    r->content_encoding = apr_pstrdup(r->pool, RSTRING_PTR(val));
     return val;
 }
 

--- a/ap_mrb_request.h
+++ b/ap_mrb_request.h
@@ -48,8 +48,13 @@ mrb_value ap_mrb_set_request_canonical_filename(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_path_info(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_args(mrb_state *mrb, mrb_value str);
 
+mrb_value ap_mrb_set_request_hostname(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_status_line(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_method(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_range(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_content_type(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_set_request_handler(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_set_request_content_encoding(mrb_state *mrb, mrb_value str);
 
 mrb_value ap_mrb_get_request_assbackwards(mrb_state *mrb, mrb_value str);
 mrb_value ap_mrb_get_request_proxyreq(mrb_state *mrb, mrb_value str);


### PR DESCRIPTION
request_rec構造体でconst char型で宣言されているメンバのset関数を作成しました。

■動作検証
以下の設定を行い、ブラウザからアクセスし、問題ないことを確認しております。

-/etc/httpd/conf/httpd.conf(以下の行追加)
LoadModule mruby_module       /usr/lib/httpd/modules/mod_mruby.so

-/etc/httpd/conf.d/mruby.conf(作成)
LoadModule mruby_module modules/mod_mruby.so
AddHandler mruby-script .mrb
mrubyTranslateNameMiddle /var/www/html/mrbfile/translate_name_middle.mrb

-/var/www/html/mrbfile/translate_name_middle.mrb(作成)
require 'Apache'
r = Apache::Request.new()
Apache.rputs("---- translate_name_middle ----<BR>")
Apache.rputs("hostname= "+r.hostname+"<BR>")
Apache.rputs("status_line= "+r.status_line+"<BR>")
Apache.rputs("method= "+r.method+"<BR>")
Apache.rputs("range= "+r.range+"<BR>")
Apache.rputs("content_encoding= "+r.content_encoding+"<BR>")

r.filename          = "/var/www/html/hooktest/translate_name_middle.html"
r.hostname          = "test_server"
r.status_line       = "test1"
r.method            = "test2"
r.range             = "test3"
r.content_encoding  = "test4"

Apache.rputs("---- request_rec changed ----<br>")
Apache.rputs("hostname= "+r.hostname+"<BR>")
Apache.rputs("status_line= "+r.status_line+"<BR>")
Apache.rputs("method= "+r.method+"<BR>")
Apache.rputs("range= "+r.range+"<BR>")
Apache.rputs("content_encoding= "+r.content_encoding+"<BR>")

Apache.return(Apache::OK)

-/var/www/html/hooktest/translate_name_middle.html(追加)
translate_name_middle

上記のファイルを準備し、apacheの起動後アクセスすると設定した値が変更されていることが確認できた。
-結果(※${hostname}はサーバのホスト名が入っている)
---- translate_name_middle ----
hostname= ${hosname}
status_line= null
method= GET
range= null
content_encoding= null
---- request_rec changed ----
hostname= test_server
status_line= test1
method= test2
range= test3
content_encoding= test4
translate_name_middle
