### PR TITLE
check for null parameter

### DIFF
--- a/ap_mrb_request.c
+++ b/ap_mrb_request.c
@@ -403,6 +403,8 @@ mrb_value ap_mrb_get_request_notes(mrb_state *mrb, mrb_value str)
     mrb_get_args(mrb, "o", &key);
     request_rec *r = ap_mrb_get_request();
     const char *val = apr_table_get(r->notes, RSTRING_PTR(key));
+    if (val == NULL)
+        return mrb_nil_value();
     return mrb_str_new(mrb, val, strlen(val));
 }
 
@@ -423,6 +425,8 @@ mrb_value ap_mrb_get_request_headers_in(mrb_state *mrb, mrb_value str)
     mrb_get_args(mrb, "o", &key);
     request_rec *r = ap_mrb_get_request();
     const char *val = apr_table_get(r->headers_in, RSTRING_PTR(key));
+    if (val == NULL)
+        return mrb_nil_value();
     return mrb_str_new(mrb, val, strlen(val));
 }
 

--- a/test/test.mrb
+++ b/test/test.mrb
@@ -60,7 +60,7 @@ Apache.rputs("<br>")
 
 Apache.rputs("<b>Headers_in Class Test</b><br>")
 hi = Apache::Headers_in.new()
-Apache.rputs("Accept-Encoding = " + hi["Accept-Encoding"] + "<br>")
+Apache.rputs("Accept-Encoding = " + (hi["Accept-Encoding"].nil? ? "nil" : hi["Accept-Encoding"]) + "<br>")
 hi["Accept-Encoding"] = "gzip"
 Apache.rputs("Accept-Encoding = " + hi["Accept-Encoding"] + "<br>")
 hiall = hi.headers_in_hash


### PR DESCRIPTION
Apache::Headers_in および Apache::Notes にて、存在しないキーを指定すると null アドレスを参照してしまうのを修正しました。
存在しないキーの場合、Hash の動作にあわせ、nil を返すようにしています。
また、Apache::Headers_out は修正はしていません。

この修正により、test/test.mrb を修正しています。
