### PR TITLE
apxs2 and apache2ctl were added to command search path.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,12 +26,12 @@ AC_FUNC_STAT
 AC_CHECK_FUNCS([memset putenv strtol])
 
 # Checks for apache tools.
-AC_PATH_PROG(APXS_PATH, apxs2 apxs, no,
+AC_PATH_PROGS(APXS_PATH, apxs2 apxs, no,
     /usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/local/apache/bin:/usr/local/apache2/bin)
 if test "$APXS_PATH" = no; then
     AC_MSG_ERROR([apxs not found.])
 fi
-AC_PATH_PROG(APACHECTL_PATH, apache2ctl apachectl, no,
+AC_PATH_PROGS(APACHECTL_PATH, apache2ctl apachectl, no,
     /usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/local/apache/bin:/usr/local/apache2/bin)
 if test "$APACHECTL_PATH" = no; then
     AC_MSG_ERROR([apachectl not found.])


### PR DESCRIPTION
Dear Matsumoto-san,

On Ubuntu and Apache 2.x, the command name of apxs and apachectl are apxs2 and apache2ctl.
And try to search apxs2 and apache2ctl first because these are more restricted name.
Of course, I think it is commonly usable on Debian and it's forks.

Please consider applying the patch.

Note:
I only checked these patches on Ubuntu 12.04 LTS (x64) with Apache 2.2.

Best regards,
