### PR TITLE
Fixed missing option -Wl,-lm for "apxs -c".

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,7 +15,8 @@ DEFS=@VERSION_DEF@
 INC=-I. -I./vendors/src -I./vendors/include
 LIB=-lm ./vendors/lib/libmruby.a ./vendors/mrblib/mrblib.o
 WC=-Wc,-std=c99,-Wall,-Werror-implicit-function-declaration,-s
-CFLAGS = $(INC) $(LIB) $(WC)
+WL=-Wl,-lm
+CFLAGS = $(INC) $(LIB) $(WC) $(WL)
 
 #   the default target
 all: libmruby.a mod_mruby.so


### PR DESCRIPTION
Dear Matsumoto-san,

This patch allows to finding math library (-lm) on linking time.
Otherwise mod_mruby.so cannot resolve math symbols.

Please consider applying the patch.

Note:
I only checked the patch on Ubuntu 12.04 LTS (x64) with Apache 2.2.

Best regards,
