### PR TITLE
Support authn_provider.

### DIFF
--- a/ap_mrb_authnprovider.c
+++ b/ap_mrb_authnprovider.c
@@ -1,0 +1,87 @@
+#include "ap_mrb_authnprovider.h"
+#include "mruby/string.h"
+#include "apr_strings.h"
+
+mrb_value mrb_str_new_or_nil(mrb_state *mrb, const char *str) {
+    if (str) {
+	return mrb_str_new(mrb, str, strlen(str));
+    } else {
+	return mrb_nil_value();
+    }
+}
+
+
+typedef struct authnprovider_rec_t {
+    request_rec *r;
+    const char *user;
+    const char *password;
+    const char *realm;
+    char *rethash;  
+} authnprovider_rec;
+
+authnprovider_rec *mrb_authnprovider_rec_state = NULL;
+
+int ap_mrb_init_authnprovider_basic(request_rec *r, const char* user, const char* password)
+{
+    mrb_authnprovider_rec_state = (authnprovider_rec *)apr_pcalloc(r->pool, sizeof (*mrb_authnprovider_rec_state));
+    mrb_authnprovider_rec_state->r = r;
+    mrb_authnprovider_rec_state->user = user;
+    mrb_authnprovider_rec_state->password = password;
+    mrb_authnprovider_rec_state->realm = NULL;
+    mrb_authnprovider_rec_state->rethash = NULL;
+    return OK;
+}
+
+int ap_mrb_init_authnprovider_digest(request_rec *r, const char* user, const char* realm)
+{
+    mrb_authnprovider_rec_state = (authnprovider_rec *)apr_pcalloc(r->pool, sizeof (*mrb_authnprovider_rec_state));
+    mrb_authnprovider_rec_state->r = r;
+    mrb_authnprovider_rec_state->user = user;
+    mrb_authnprovider_rec_state->password = NULL;
+    mrb_authnprovider_rec_state->realm = realm;
+    mrb_authnprovider_rec_state->rethash = NULL;
+    return OK;
+}
+
+char* ap_mrb_get_authnprovider_digest_rethash()
+{
+    return mrb_authnprovider_rec_state->rethash;
+}
+
+authnprovider_rec* ap_mrb_get_authnprovider()
+{
+    return mrb_authnprovider_rec_state;
+}
+
+mrb_value ap_mrb_get_authnprovider_user(mrb_state *mrb, mrb_value str)
+{
+    authnprovider_rec *anp = ap_mrb_get_authnprovider();
+    return mrb_str_new_or_nil(mrb, anp->user);
+}
+
+mrb_value ap_mrb_get_authnprovider_password(mrb_state *mrb, mrb_value str)
+{
+    authnprovider_rec *anp = ap_mrb_get_authnprovider();
+    return mrb_str_new_or_nil(mrb, anp->password);
+}
+
+mrb_value ap_mrb_get_authnprovider_realm(mrb_state *mrb, mrb_value str)
+{
+    authnprovider_rec *anp = ap_mrb_get_authnprovider();
+    return mrb_str_new_or_nil(mrb, anp->realm);
+}
+
+mrb_value ap_mrb_get_authnprovider_rethash(mrb_state *mrb, mrb_value str)
+{
+    authnprovider_rec *anp = ap_mrb_get_authnprovider();
+    return mrb_str_new_or_nil(mrb, anp->rethash);
+}
+
+mrb_value ap_mrb_set_authnprovider_rethash(mrb_state *mrb, mrb_value str)
+{
+    mrb_value val;
+    authnprovider_rec *anp = ap_mrb_get_authnprovider();
+    mrb_get_args(mrb, "o", &val);
+    anp->rethash = apr_pstrdup(anp->r->pool, RSTRING_PTR(val));
+    return val;
+}

--- a/ap_mrb_authnprovider.h
+++ b/ap_mrb_authnprovider.h
@@ -1,0 +1,20 @@
+#ifndef AP_MRB_AUTHNPROVIDER_H
+#define AP_MRB_AUTHNPROVIDER_H
+
+#include "mruby.h"
+#include "http_request.h"
+#include "mod_auth.h"
+
+int ap_mrb_init_authnprovider_basic(request_rec *r, const char* user, const char* password);
+int ap_mrb_init_authnprovider_digest(request_rec *r, const char* user, const char* realm);
+
+char* ap_mrb_get_authnprovider_digest_rethash();
+
+mrb_value ap_mrb_get_authnprovider_user(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_authnprovider_password(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_authnprovider_realm(mrb_state *mrb, mrb_value str);
+mrb_value ap_mrb_get_authnprovider_rethash(mrb_state *mrb, mrb_value str);
+
+mrb_value ap_mrb_set_authnprovider_rethash(mrb_state *mrb, mrb_value str);
+
+#endif

--- a/ap_mrb_init.c
+++ b/ap_mrb_init.c
@@ -6,6 +6,7 @@
 #include "ap_mrb_string.h"
 #include "ap_mrb_env.h"
 #include "ap_mrb_scoreboard.h"
+#include "ap_mrb_authnprovider.h"
 
 struct RClass *class;
 struct RClass *class_request;
@@ -16,6 +17,7 @@ struct RClass *class_headers_out;
 struct RClass *class_env;
 struct RClass *class_notes;
 struct RClass *class_scoreboard;
+struct RClass *class_authnprovider;
 
 int ap_mruby_class_init(mrb_state *mrb)
 {
@@ -225,6 +227,17 @@ int ap_mruby_class_init(mrb_state *mrb)
     mrb_define_method(mrb, class_request, "no_cache", ap_mrb_get_request_no_cache, ARGS_NONE());
     mrb_define_method(mrb, class_request, "no_local_copy", ap_mrb_get_request_no_local_copy, ARGS_NONE());
 
+    class_authnprovider = mrb_define_class_under(mrb, class, "AuthnProvider", mrb->object_class);
+    mrb_define_const(mrb, class_authnprovider, "AUTH_DENIED", mrb_fixnum_value(AUTH_DENIED));
+    mrb_define_const(mrb, class_authnprovider, "AUTH_GRANTED", mrb_fixnum_value(AUTH_GRANTED));
+    mrb_define_const(mrb, class_authnprovider, "AUTH_USER_FOUND", mrb_fixnum_value(AUTH_USER_FOUND));
+    mrb_define_const(mrb, class_authnprovider, "AUTH_USER_NOT_FOUND", mrb_fixnum_value(AUTH_USER_NOT_FOUND));
+    mrb_define_const(mrb, class_authnprovider, "AUTH_GENERAL_ERROR", mrb_fixnum_value(AUTH_GENERAL_ERROR));
+    mrb_define_method(mrb, class_authnprovider, "user", ap_mrb_get_authnprovider_user, ARGS_NONE());
+    mrb_define_method(mrb, class_authnprovider, "password", ap_mrb_get_authnprovider_password, ARGS_NONE());
+    mrb_define_method(mrb, class_authnprovider, "realm", ap_mrb_get_authnprovider_realm, ARGS_NONE());
+    mrb_define_method(mrb, class_authnprovider, "rethash", ap_mrb_get_authnprovider_rethash, ARGS_NONE());
+    mrb_define_method(mrb, class_authnprovider, "rethash=", ap_mrb_set_authnprovider_rethash, ARGS_ANY());
 
     return OK;
 }

--- a/mod_mruby.h
+++ b/mod_mruby.h
@@ -16,6 +16,13 @@
 
 typedef struct {
 
+    const char *mod_mruby_authn_check_password_code;
+    const char *mod_mruby_authn_get_realm_hash_code;
+
+} mruby_dir_config_t;
+
+typedef struct {
+
     int mod_mruby_handler_code_native_n;
     const char *mod_mruby_handler_code_native;
     const char *mod_mruby_handler_code;


### PR DESCRIPTION
Dear matsumoto-san,

I have implemented authn_provider to be able to authentication in mod_mruby.
This version supports both basic and digest authentications.

The name of AuthBasicProvider and AuthDigestProvider are "mruby" at this commit.

If that's all right, please import it.

Best regards,
