### PR TITLE
Fix features handling in configure.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4,7 +4,7 @@
 ##
 
 # target module source
-TARGET=mod_mruby.c ap_mrb_*.c lib/*/*.c
+TARGET=mod_mruby.c ap_mrb_*.c @FEATURE_TARGETS@
 
 #   the used tools
 APXS=@APXS_PATH@
@@ -13,10 +13,10 @@ APACHECTL=@APACHECTL_PATH@
 #   additional user defines, includes and libraries
 DEFS=@DEFS@
 INC=-I. -I./vendors/src -I./vendors/include
-LIB=-lm -lcrypto -lhiredis ./vendors/lib/libmruby.a ./vendors/mrblib/mrblib.o
+LIB=@LIBS@ ./vendors/lib/libmruby.a ./vendors/mrblib/mrblib.o
 WC=-Wc,-std=c99,-Wall,-Werror-implicit-function-declaration,-s
-WL=-Wl,-lm,-lcrypto,-lhiredis
-CFLAGS = $(INC) $(LIB) $(WC) $(WL)
+LDFLAGS=@LDFLAGS@
+CFLAGS = $(INC) $(LIB) $(WC) 
 
 #   the default target
 all: libmruby.a mod_mruby.so
@@ -26,7 +26,7 @@ extend: libmruby-ex.a mod_mruby.so
 
 #   compile the DSO file
 mod_mruby.so: $(TARGET)
-	$(APXS) -c $(DEFS) $(CFLAGS) $(TARGET)
+	$(APXS) -c $(DEFS) $(CFLAGS) $(LDFLAGS) $(TARGET)
 
 #   install the DSO file into the Apache installation
 #   and activate it in the Apache configuration

--- a/configure.in
+++ b/configure.in
@@ -13,10 +13,11 @@ AC_PROG_MAKE_SET
 # Checks for libraries.
 # FIXME: Replace `main' with a function in `-lm':
 AC_CHECK_LIB([m], [main])
+AC_CHECK_LIB([crypto], [main])
 
 # Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS([string.h unistd.h hiredis/hiredis.h],,[AC_MSG_ERROR(not found.)])
+AC_CHECK_HEADERS([string.h unistd.h],,[AC_MSG_ERROR(not found the header file for mod_mruby.)])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
@@ -64,12 +65,16 @@ esac
 AC_ARG_ENABLE([redis],
     [AS_HELP_STRING([--enable-redis],
         [redis feature (default is no)])],
-    [],
+    [AC_CHECK_HEADERS([hiredis/hiredis.h],,[AC_MSG_ERROR(not found the header file for redis.)])
+     AC_CHECK_LIB([hiredis], [main])
+    ],
     [enable_redis=no] 
 )
 
 AS_IF([test "x$enable_redis" != xno],
-    [AC_DEFINE([ENABLE_REDIS], [1], [redis support])]
+    [AC_DEFINE([ENABLE_REDIS], [1], [redis support])
+     FEATURE_TARGETS="lib/redis/*.c ${FEATURE_TARGETS}"
+    ]
 )
 
 AC_ARG_ENABLE([hello],
@@ -80,8 +85,14 @@ AC_ARG_ENABLE([hello],
 )
 
 AS_IF([test "x$enable_hello" != xno],
-    [AC_DEFINE([ENABLE_HELLO], [1], [hello support])]
+    [AC_DEFINE([ENABLE_HELLO], [1], [hello support])
+     FEATURE_TARGETS="lib/hello/*.c ${FEATURE_TARGETS}"
+    ]
 )
+
+WLFLAG="-Wl,`echo "$LIBS" | sed -e "s/\s\+/,/g"`"
+LDFLAGS="$WLFLAG $LDFLAGS"
+AC_SUBST(FEATURE_TARGETS)
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Dear Matsumoto-san,

I've created a patch for better feature handling.
Without this, environments which not include libhiredis-dev will cause header missing error in ./configure.
- Separate indispensable configuration and headers from features' ones.
  *\* Add and use @FEATURES_TARGET@ as replacement of lib/_/_.c
  *\* Use @LIBS@
  *\* Use LDFLAGS as replacement of WL in Makefile.in.
  *\* -Wl,<lib,lib,...> will be automatically generated from LIBS.

Please import this when it's OK.

Best regards,
