### PR TITLE
Select mruby implementation in configure

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,13 +16,11 @@ INC=-I. -I./vendors/src -I./vendors/include
 LIB=@LIBS@ ./vendors/lib/libmruby.a ./vendors/mrblib/mrblib.o
 WC=-Wc,-std=c99,-Wall,-Werror-implicit-function-declaration,-s
 LDFLAGS=@LDFLAGS@
-CFLAGS = $(INC) $(LIB) $(WC) 
+CFLAGS=$(INC) $(LIB) $(WC)
+MRUBY_REPOS=@MRUBY_REPOS@
 
 #   the default target
 all: libmruby.a mod_mruby.so
-
-#   build for iij extended lib
-extend: libmruby-ex.a mod_mruby.so
 
 #   compile the DSO file
 mod_mruby.so: $(TARGET)
@@ -52,22 +50,9 @@ stop:
 # libmruby.a
 tmp/mruby:
 	mkdir -p tmp vendors
-	cd tmp; git clone git://github.com/mruby/mruby.git
+	cd tmp; git clone "$(MRUBY_REPOS)"
 
 libmruby.a: tmp/mruby
-	cd tmp/mruby && make CFLAGS="-O3 -fPIC"
-	cp -r tmp/mruby/include vendors/
-	cp -r tmp/mruby/lib vendors/
-	cp -r tmp/mruby/src vendors/
-	cp -r tmp/mruby/bin vendors/
-	cp -r tmp/mruby/mrblib vendors/
-
-# libmruby.a (+iij extended lib)
-tmp/mruby-ex:
-	mkdir -p tmp vendors
-	cd tmp; git clone git://github.com/iij/mruby.git
-
-libmruby-ex.a: tmp/mruby-ex
 	cd tmp/mruby && make CFLAGS="-O3 -fPIC"
 	cp -r tmp/mruby/include vendors/
 	cp -r tmp/mruby/lib vendors/

--- a/configure.in
+++ b/configure.in
@@ -26,6 +26,33 @@ AC_C_CONST
 AC_FUNC_STAT
 AC_CHECK_FUNCS([memset putenv strtol])
 
+# Select mruby repos uri
+AC_ARG_WITH(mruby, AC_HELP_STRING([--with-mruby=mruby or iij or Git URI],
+    [name or git uri to the mruby implementation. (default is mruby)]),
+    [with_mruby="$with_mruby"],
+    [with_mruby=mruby])
+
+AC_SUBST(MRUBY_REPOS)
+case "$with_mruby" in
+mruby|yes|'')   # mruby/mruby
+    MRUBY_REPOS=git://github.com/mruby/mruby.git ;;
+iij|extend)     # iij/mruby
+    MRUBY_REPOS=git://github.com/iij/mruby.git ;;
+*::/*)
+    MRUBY_REPOS="$with_mruby" ;;
+*)
+    if test -d "$with_mruby" ; then
+        MRUBY_REPOS="$with_mruby"
+    else
+        AC_MSG_ERROR([--with-mruby: [$with_mruby] is not a git uri.])
+    fi
+esac
+AS_ECHO(["--with-mruby: [$MRUBY_REPOS] will be used."])
+
+if test "$APXS_PATH" = no; then
+    AC_MSG_ERROR([apxs2 and apsx not found.])
+fi
+
 # Checks for apache tools.
 AC_ARG_WITH(apxs, AC_HELP_STRING([--with-apxs=FILE],
     [pathname to the Apache apxs tool [[apxs]]]),


### PR DESCRIPTION
Dear matsumoto san,

I've created patch to improve selecting mruby implementation.

Added --with-mruby in configure.in
 --with-mruby=mruby then mruby/mruby will be used  as mruby implementation.
 --with-mruby=iij then iij/mruby will be used.
 --with-mruby=<protocol>://<url> then <protocol>://<url> will be used.
 --with-mruby=local/path then local/path will be used.
and the default value is mruby.

Deleted "extend" target in Makefile.in
Instead, using $(MRUBY_REPOS) as the repository path.

I think this is natural way.
If it's OK, please merge this.

Best regards,
