### PR TITLE
Split clobber from clean to avoid frequently git clone

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -35,8 +35,12 @@ install:
 
 #   cleanup
 clean:
-	-rm -rf .libs *.o *.so *.lo *.la *.slo *.loT tmp vendors config.log config.status autom4te.cache
+	-rm -rf .libs *.o *.so *.lo *.la *.slo *.loT
 	-rm -rf ./lib/*/.libs ./lib/*/*.o ./lib/*/*.lo ./lib/*/*.slo
+
+#   clobber
+clobber: clean
+	-rm -rf tmp vendors config.log config.status autom4te.cache
 
 #   reload the module by installing and restarting Apache
 reload: install restart


### PR DESCRIPTION
Dear matsumoto san,

To avoid frequently git clone, I split clobber from clean.
Now, clean will not delete mruby implementations and generated files by configure.

Best regards,
