### PR TITLE
change to use `https://` instead of `git://` in build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mruby"]
 	path = mruby
-	url = git://github.com/mruby/mruby.git
+	url = https://github.com/mruby/mruby.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get -y install libmarkdown2-dev
 RUN apt-get -y install libcap-dev
 RUN apt-get -y install libcgroup-dev
 
-RUN cd /usr/local/src/ && git clone git://github.com/matsumoto-r/mod_mruby.git
+RUN cd /usr/local/src/ && git clone https://github.com/matsumoto-r/mod_mruby.git
 RUN cd /usr/local/src/mod_mruby && sh build.sh && make install
 
 EXPOSE 80

--- a/configure
+++ b/configure
@@ -3647,9 +3647,9 @@ fi
 
 case "$with_mruby" in
 mruby|yes|'')   # mruby/mruby
-    MRUBY_REPOS=git://github.com/mruby/mruby.git ;;
+    MRUBY_REPOS=https://github.com/mruby/mruby.git ;;
 iij|extend)     # iij/mruby
-    MRUBY_REPOS=git://github.com/iij/mruby.git ;;
+    MRUBY_REPOS=https://github.com/iij/mruby.git ;;
 *::/*)
     MRUBY_REPOS="$with_mruby" ;;
 *)

--- a/configure.in
+++ b/configure.in
@@ -35,9 +35,9 @@ AC_ARG_WITH(mruby, AC_HELP_STRING([--with-mruby=mruby or iij or Git URI],
 AC_SUBST(MRUBY_REPOS)
 case "$with_mruby" in
 mruby|yes|'')   # mruby/mruby
-    MRUBY_REPOS=git://github.com/mruby/mruby.git ;;
+    MRUBY_REPOS=https://github.com/mruby/mruby.git ;;
 iij|extend)     # iij/mruby
-    MRUBY_REPOS=git://github.com/iij/mruby.git ;;
+    MRUBY_REPOS=https://github.com/iij/mruby.git ;;
 *::/*)
     MRUBY_REPOS="$with_mruby" ;;
 *)

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -15,5 +15,5 @@ RUN apt-get -y install libmarkdown2-dev
 RUN apt-get -y install libcap-dev
 RUN apt-get -y install libcgroup-dev
 #
-RUN cd /usr/local/src/ && git clone git://github.com/matsumoto-r/mod_mruby.git
+RUN cd /usr/local/src/ && git clone https://github.com/matsumoto-r/mod_mruby.git
 RUN cd /usr/local/src/mod_mruby && sh test.sh


### PR DESCRIPTION
Hi, I suggest using `https://` protocol instead of `git://`.

In some scenarios (like in some companies), the port which git protocol uses  is blocked by firewall policies.
