### PR TITLE
Support custom timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - HTTPD_VERSION=httpd-2.2.32
     APR=apr-1.5.2
     APR_UTIL=apr-util-1.5.4
-    HTTPD_CONFIG_OPT='--enable-module=all --enable-mods-shared=all --enable-proxy --enable-proxy-http'
+    HTTPD_CONFIG_OPT='--enable-module=all --enable-mods-shared=all --enable-proxy --enable-proxy-http --enable-cgid'
   - HTTPD_VERSION=httpd-2.4.25
     APR=apr-1.5.2
     APR_UTIL=apr-util-1.5.4

--- a/Makefile.in
+++ b/Makefile.in
@@ -65,6 +65,7 @@ test:
 		-e 's|__APLIBEXECDIR__|$(APLIBEXECDIR)|g' \
 		-e 's|__APDOCROOT__|$(APDOCROOT)|g' \
 		./test/conf/mod_mruby_test.conf >> ./test/conf/httpd.conf
+	cp -pr ./test/htdocs/* $(APDOCROOT)/.
 	$(APACHECTL) -f $(shell pwd)/test/conf/httpd.conf -k start
 	cp -p ./test/build_config.rb $(MRUBY_TEST_ROOT)/.
 	cd $(MRUBY_TEST_ROOT) && rake clean && $(RAKE)

--- a/src/ap_mrb_server.c
+++ b/src/ap_mrb_server.c
@@ -22,6 +22,18 @@ static mrb_value ap_mrb_set_server_error_fname(mrb_state *mrb, mrb_value str)
   return val;
 }
 
+static mrb_value ap_mrb_set_server_timeout(mrb_state *mrb, mrb_value self)
+{
+  mrb_int timeout;
+  request_rec *r = ap_mrb_get_request();
+
+  mrb_get_args(mrb, "i", &timeout);
+
+  r->server->timeout = timeout;
+
+  return self;
+}
+
 // char read
 static mrb_value ap_mrb_get_server_error_fname(mrb_state *mrb, mrb_value str)
 {
@@ -180,6 +192,7 @@ void ap_mruby_server_init(mrb_state *mrb, struct RClass *class_core)
   mrb_define_method(mrb, class_server, "limit_req_fieldsize", ap_mrb_get_server_limit_req_fieldsize, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_server, "limit_req_fields", ap_mrb_get_server_limit_req_fields, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_server, "timeout", ap_mrb_get_server_timeout, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_server, "timeout=", ap_mrb_set_server_timeout, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_server, "keep_alive_timeout", ap_mrb_get_server_keep_alive_timeout, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_server, "redirect_server_port", ap_mrb_get_server_port, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_server, "defn_line_number", ap_mrb_get_server_defn_line_number, MRB_ARGS_NONE());

--- a/test/conf/mod_mruby_test.conf
+++ b/test/conf/mod_mruby_test.conf
@@ -1,6 +1,12 @@
 Loglevel debug
 Listen 38080
 
+LoadModule cgid_module modules/mod_cgid.so
+<Location />
+    AddHandler cgi-script .cgi
+    Options Indexes FollowSymLinks ExecCGI
+</Location>
+
 <Location /server-version>
     mrubyHandlerMiddleCode 'Apache.rputs Apache.server_version'
 </Location>
@@ -228,3 +234,13 @@ Listen 127.0.0.1:8081
    end;                                                            \
    run p                 '
 </Location>
+
+# test for cutom timeout
+<Location /sleep.cgi>
+  mrubyFixupsMiddleCode ' \
+    Userdata.new.default_timeout = Apache::Server.new.timeout; \
+    Apache::Server.new.timeout = 3000000; \
+    Apache.log Apache::APLOG_NOTICE, "default timeout: #{Userdata.new.default_timeout} current_timeout: #{Apache::Server.new.timeout}"'
+  mrubyLogTransactionMiddleCode 'Apache::Server.new.timeout = Userdata.new.default_timeout'
+</Location>
+

--- a/test/htdocs/sleep.cgi
+++ b/test/htdocs/sleep.cgi
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo -ne "Content-Type: text/html; charset=UTF-8\r\n\r\n"
+
+sleep 5
+
+echo "sleep done"

--- a/test/t/mod_mruby.rb
+++ b/test/t/mod_mruby.rb
@@ -208,4 +208,17 @@ t.assert('mod_mruby', 'location /response_time') do
   t.assert_equal "2", res["body"]
 end
 
+t.assert('mod_mruby', 'location /custom_timeout') do
+  # custom timeout 3 sec by mod_mruby 
+  timer_msec = 4000
+  
+  start = Time.now.to_i * 1000 + Time.now.usec / 1000
+  # sleeping 10 sec in sleep.cgi
+  res = HttpRequest.new.get base + '/sleep.cgi'
+  finish = Time.now.to_i * 1000 + Time.now.usec / 1000
+
+  p (finish - start)
+  t.assert_true (finish - start) < timer_msec
+end
+
 t.report


### PR DESCRIPTION
```ruby
# test for cutom timeout from 10 sec to 3 sec per file
<Location /sleep.cgi>
  mrubyFixupsMiddleCode ' \
    Userdata.new.default_timeout = Apache::Server.new.timeout; \
    Apache::Server.new.timeout = 3000000; \
    Apache.log Apache::APLOG_NOTICE, "default timeout: #{Userdata.new.default_timeout} current_timeout: #{Apache::Server.new.timeout}"'
  mrubyLogTransactionMiddleCode 'Apache::Server.new.timeout = Userdata.new.default_timeout'
</Location>
```