### PR TITLE
Support Set-Cookie header with multiple cookies

### DIFF
--- a/src/ap_mrb_request.c
+++ b/src/ap_mrb_request.c
@@ -392,9 +392,14 @@ static mrb_value ap_mrb_set_request_headers_out(mrb_state *mrb, mrb_value str)
 {
   mrb_value key, val;
   request_rec *r = ap_mrb_get_request();
+  const char *set_cookie = "Set-Cookie";
 
   mrb_get_args(mrb, "oo", &key, &val);
-  apr_table_set(r->headers_out, mrb_str_to_cstr(mrb, key), mrb_str_to_cstr(mrb, val));
+  if (strcmp(set_cookie, mrb_str_to_cstr(mrb, key)) == 0) {
+    apr_table_add(r->headers_out, mrb_str_to_cstr(mrb, key), mrb_str_to_cstr(mrb, val));
+  } else {
+    apr_table_set(r->headers_out, mrb_str_to_cstr(mrb, key), mrb_str_to_cstr(mrb, val));
+  }
   return val;
 }
 

--- a/test/htdocs/header.rb
+++ b/test/htdocs/header.rb
@@ -1,5 +1,9 @@
 r = Apache::Request.new
 
+r.headers_out["Set-Cookie"] = "hoge1"
+r.headers_out["Set-Cookie"] = "hoge2"
+r.headers_out["X-RESPONSE-HEADER"] = "hogehoge"
+
 unless r.headers_in["X-REQUEST-HEADER"].nil?
   r.headers_out["X-RESPONSE-HEADER"] = r.headers_in["X-REQUEST-HEADER"]
   Apache.rputs "X-REQUEST-HEADER found"

--- a/test/t/mod_mruby.rb
+++ b/test/t/mod_mruby.rb
@@ -55,7 +55,7 @@ t.assert('mod_mruby', 'location /header') do
   t.assert_true res1["set-cookie"].instance_of?(Array)
   t.assert_equal 2, res1["set-cookie"].length
   t.assert_equal "hoge1", res1["set-cookie"][0]
-  t.assert_equal "hoge2", res2["set-cookie"][1]
+  t.assert_equal "hoge2", res1["set-cookie"][1]
   t.assert_false res1["x-response-header"].instance_of?(Array)
 
   t.assert_equal "X-REQUEST-HEADER not found", res1["body"]

--- a/test/t/mod_mruby.rb
+++ b/test/t/mod_mruby.rb
@@ -52,6 +52,12 @@ t.assert('mod_mruby', 'location /header') do
   res1 = HttpRequest.new.get base + '/header'
   res2 = HttpRequest.new.get base + '/header', nil, {"X-REQUEST-HEADER" => "hoge"}
 
+  t.assert_true res1["set-cookie"].instance_of?(Array)
+  t.assert_equal 2, res1["set-cookie"].length
+  t.assert_equal "hoge1", res1["set-cookie"][0]
+  t.assert_equal "hoge2", res2["set-cookie"][1]
+  t.assert_false res1["x-response-header"].instance_of?(Array)
+
   t.assert_equal "X-REQUEST-HEADER not found", res1["body"]
   t.assert_equal "nothing", res1["x-response-header"]
   t.assert_equal "X-REQUEST-HEADER found", res2["body"]


### PR DESCRIPTION
headers_out["Set-Cookie"]で複数のCookieを設定できるように修正しました。
Set-Cookieというキーの場合のみ複数登録できるようにしています。
ご確認いただき、よろしければ merge していただけると嬉しいです。