### PR TITLE
Add Apache::Finfo#mode for unix compatible mode_t

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 install:
     - sudo apt-get -qq install rake bison libcurl4-openssl-dev libmarkdown2-dev
 env:
-  - HTTPD_VERSION=httpd-2.4.41
+  - HTTPD_VERSION=httpd-2.4.43
     APR=apr-1.7.0
     APR_UTIL=apr-util-1.6.1
     HTTPD_CONFIG_OPT=

--- a/src/ap_mrb_request.c
+++ b/src/ap_mrb_request.c
@@ -7,7 +7,6 @@
 #include "mod_mruby.h"
 #include "ap_mrb_init.h"
 #include "ap_mrb_request.h"
-#include "apr_arch_file_io.h"
 #include "mruby/hash.h"
 
 #define CORE_PRIVATE
@@ -496,10 +495,12 @@ static mrb_value ap_mrb_get_request_finfo_protection(mrb_state *mrb, mrb_value s
 }
 
 #if !defined(OS2) && !defined(WIN32)
+mode_t apr_unix_perms2mode(apr_fileperms_t perms);
+
 static mrb_value ap_mrb_get_request_finfo_perm2mode(mrb_state *mrb, mrb_value str)
 {
   request_rec *r = ap_mrb_get_request();
-  mode_t mode = apr_unix_perms2mode(r->finfo.protection)
+  mode_t mode = apr_unix_perms2mode(r->finfo.protection);
   return mrb_fixnum_value((mrb_int)mode);
 }
 #endif

--- a/test/test.rb
+++ b/test/test.rb
@@ -139,6 +139,7 @@ module ModMruby
       Apache::echo "## Finfo Class Test"
       f = Apache::Request.new.finfo
       Apache.echo "- permission = #{f.permission.to_s}"
+      Apache.echo "- mode = #{"%o" % f.mode}" if f.respond_to?(:mode)
       Apache.echo "- filetype regular file = #{f.filetype == Apache::Finfo::APR_REG}"
       Apache.echo "- user = #{f.user.to_s}"
       Apache.echo "- group = #{f.group.to_s}"

--- a/test/test_md.rb
+++ b/test/test_md.rb
@@ -138,6 +138,7 @@ module ModMruby
       Apache::rputs "## Finfo Class Test".to_html
       f = Apache::Request.new.finfo
       Apache.rputs "- permission = #{f.permission.to_s}".to_html
+      Apache.rputs "- mode = #{"%o" % f.mode}".to_html if f.respond_to?(:mode)
       Apache.rputs "- filetype regular file = #{f.filetype == Apache::Finfo::APR_REG}".to_html
       Apache.rputs "- user = #{f.user.to_s}".to_html
       Apache.rputs "- group = #{f.group.to_s}".to_html


### PR DESCRIPTION
Current `Apache::Finfo#permission` represents `apr_fileperms_t`, which is for APR internal use, and not compatible with UNIX/Linux `mode_t`.

The utility `apr_unix_perms2mode()` can convert `apr_fileperms_t` into `mode_t`.
(But using this function is a little hacky. header for `apr_unix_perms2mode()` is missing, but `apr_unix_perms2mode()` is exported at `libapr-1.so` in many distro)

<details>

```console
$ readelf -s /usr/lib/x86_64-linux-gnu/libapr-1.so.0.6.3 | grep perms
   436: 00000000000172d0   152 FUNC    GLOBAL DEFAULT   12 apr_unix_mode2perms
   469: 0000000000017230   156 FUNC    GLOBAL DEFAULT   12 apr_unix_perms2mode
   502: 000000000001a7f0     9 FUNC    GLOBAL DEFAULT   12 apr_global_mutex_perms_se
   521: 000000000001b960     7 FUNC    GLOBAL DEFAULT   12 apr_proc_mutex_perms_set
   567: 0000000000026d70   158 FUNC    GLOBAL DEFAULT   12 apr_shm_perms_set
   605: 0000000000027ce0    77 FUNC    GLOBAL DEFAULT   12 apr_procattr_perms_set_re
   631: 0000000000018130    39 FUNC    GLOBAL DEFAULT   12 apr_file_perms_set
   708: 00000000000237d0    82 FUNC    GLOBAL DEFAULT   12 apr_socket_perms_set
```

</details>

I have added `Apache::Finfo#mode` to use `mode_t`!